### PR TITLE
feat: rebuild treningsapp prototype UI

### DIFF
--- a/SuperAppFactory/Builds/treningsapp/index.html
+++ b/SuperAppFactory/Builds/treningsapp/index.html
@@ -1,1 +1,251 @@
-null
+<!DOCTYPE html>
+<html lang="no">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SuperAppFactory – Treningsapp</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: radial-gradient(circle at top, #1f2937 0%, #0b1120 80%);
+      color: #e3f9e5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2.5rem 1.5rem;
+    }
+    main {
+      width: min(520px, 100%);
+      background: rgba(12, 25, 40, 0.85);
+      border: 1px solid rgba(0, 255, 153, 0.35);
+      border-radius: 18px;
+      box-shadow: 0 24px 40px rgba(0, 0, 0, 0.45);
+      padding: 2.5rem 2rem;
+      backdrop-filter: blur(6px);
+    }
+    h1 {
+      margin-top: 0;
+      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      letter-spacing: 0.03em;
+      text-align: center;
+    }
+    p.lead {
+      text-align: center;
+      margin-bottom: 2rem;
+      color: #a7f3d0;
+    }
+    label {
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+    }
+    input[type="text"] {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0.75rem 1rem;
+      border-radius: 999px;
+      border: 1px solid rgba(0, 255, 153, 0.4);
+      background: rgba(15, 118, 110, 0.2);
+      color: #f9fafb;
+      font-size: 1rem;
+      transition: border 120ms ease, box-shadow 120ms ease;
+    }
+    input[type="text"]:focus {
+      outline: none;
+      border-color: #34d399;
+      box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.25);
+    }
+    .actions {
+      display: grid;
+      gap: 0.75rem;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      margin: 2rem 0 1.5rem;
+    }
+    button {
+      border: none;
+      border-radius: 999px;
+      padding: 0.85rem 1rem;
+      background: linear-gradient(135deg, #34d399, #22d3ee);
+      color: #042f2e;
+      font-weight: 700;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+    }
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 20px rgba(56, 189, 248, 0.25);
+    }
+    button:active {
+      transform: translateY(0);
+      filter: brightness(0.95);
+    }
+    #status {
+      min-height: 1.5rem;
+      text-align: center;
+      font-weight: 600;
+      color: #fef3c7;
+    }
+    h2 {
+      margin-top: 2.25rem;
+      font-size: 1.1rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #67e8f9;
+    }
+    ul#history {
+      list-style: none;
+      padding-left: 0;
+      margin: 0.75rem 0 0;
+      display: grid;
+      gap: 0.75rem;
+    }
+    ul#history li {
+      background: rgba(8, 31, 37, 0.7);
+      border: 1px solid rgba(45, 212, 191, 0.25);
+      border-radius: 14px;
+      padding: 0.75rem 1rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+    }
+    ul#history li span.kind {
+      font-weight: 700;
+      color: #bef264;
+    }
+    ul#history li time {
+      font-size: 0.85rem;
+      color: #bae6fd;
+      white-space: nowrap;
+    }
+    ul#history li.empty {
+      justify-content: center;
+      color: #94a3b8;
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Treningsapp Prototype</h1>
+    <p class="lead">Trening for Pernille 💖 Sol 🌞 Silke 🌸</p>
+
+    <label for="note">Notat eller øvelse</label>
+    <input id="note" type="text" placeholder="F.eks. 3×10 knebøy" autocomplete="off">
+
+    <div class="actions">
+      <button type="button" onclick="logWorkout()">📋 Logg økt</button>
+      <button type="button" onclick="startTrip()">🚀 Start Trip</button>
+      <button type="button" onclick="backup()">🔐 Vault Backup</button>
+    </div>
+
+    <p id="status" role="status" aria-live="polite"></p>
+
+    <h2>Siste hendelser</h2>
+    <ul id="history"></ul>
+  </main>
+
+  <script>
+    const statusField = document.getElementById("status");
+    const historyList = document.getElementById("history");
+    const noteField = document.getElementById("note");
+    const STORAGE_KEY = "treningsapp.history";
+
+    function loadHistory() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : [];
+      } catch (err) {
+        console.warn("Kunne ikke laste historikk", err);
+        return [];
+      }
+    }
+
+    let history = loadHistory();
+
+    function persistHistory() {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+      } catch (err) {
+        console.warn("Kunne ikke lagre historikk", err);
+      }
+    }
+
+    function formatTimestamp(iso) {
+      const date = new Date(iso);
+      const time = date.toLocaleTimeString("no-NO", { hour: "2-digit", minute: "2-digit" });
+      const day = date.toLocaleDateString("no-NO", { weekday: "short", day: "2-digit", month: "short" });
+      return `${day} • ${time}`;
+    }
+
+    function renderHistory() {
+      historyList.innerHTML = "";
+      if (!history.length) {
+        const li = document.createElement("li");
+        li.className = "empty";
+        li.textContent = "Ingen hendelser registrert ennå.";
+        historyList.appendChild(li);
+        return;
+      }
+
+      history.forEach((entry) => {
+        const li = document.createElement("li");
+        const kind = document.createElement("span");
+        kind.className = "kind";
+        kind.textContent = entry.label;
+
+        const details = document.createElement("span");
+        details.textContent = entry.details;
+
+        const time = document.createElement("time");
+        time.dateTime = entry.timestamp;
+        time.textContent = formatTimestamp(entry.timestamp);
+
+        li.append(kind, details, time);
+        historyList.appendChild(li);
+      });
+    }
+
+    function registerEvent(label, message, details) {
+      const timestamp = new Date().toISOString();
+      history = [
+        { label, message, details, timestamp },
+        ...history.slice(0, 19)
+      ];
+      persistHistory();
+      renderHistory();
+      statusField.textContent = `${message} (${formatTimestamp(timestamp)})${details ? ` – ${details}` : ""}`;
+    }
+
+    function logWorkout() {
+      const note = noteField.value.trim();
+      registerEvent("Økt", "📋 Økt logget", note || "Rutine registrert");
+      noteField.value = "";
+      noteField.focus();
+    }
+
+    function startTrip() {
+      registerEvent("Trip", "🚀 Trip aktivert", "Sensorene er klare");
+    }
+
+    function backup() {
+      registerEvent("Backup", "🔐 Vault-synk pågår", "Sikrer dagens data");
+    }
+
+    noteField.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        logWorkout();
+      }
+    });
+
+    renderHistory();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the placeholder treningsapp build with a styled prototype page
- add interactive logging, trip, and backup actions with persisted history

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f4235a31dc832fbd487f7640e9e97e