### PR TITLE
Add Night School pipeline and skill card templates

### DIFF
--- a/Docs/AI_Skills/g_motor/roi_tuning_001.yaml
+++ b/Docs/AI_Skills/g_motor/roi_tuning_001.yaml
@@ -1,0 +1,30 @@
+id: SKILL:G_MOTOR:ROI_TUNING:001
+module: g_motor
+topic: roi_optimization
+confidence: 0.87
+
+rule:
+  trigger: "When job proposal has ROI < threshold AND risk_score > 0.6"
+  action: |
+    1. Increase required ROI by 15%
+    2. Flag for manual review if strategic_importance > 0.8
+    3. Log decision to L1_RAW with full context
+  expected_outcome: "Better hit rate on profitable jobs, reduced wasted compute"
+
+anti_rule:
+  never_when:
+    - "Job is marked as 'strategic_experiment'"
+    - "Job comes from trusted_partner list"
+  reason: "Strategic jobs may have indirect ROI not captured in immediate metrics"
+
+evidence:
+  episode_count: 23
+  success_rate: 0.87
+  key_episodes:
+    - L2_SEMANTIC:cluster_42
+    - L2_SEMANTIC:cluster_58
+
+metadata:
+  created: 2025-12-01T02:15:00Z
+  impact_score: 0.82
+  tags: [economy, optimization, risk_management]

--- a/Docs/NightSchool/first_run_checklist.md
+++ b/Docs/NightSchool/first_run_checklist.md
@@ -1,0 +1,34 @@
+# Night School First Run Checklist
+
+## Pre-flight
+- [ ] `ANTHROPIC_API_KEY` set in environment
+- [ ] `~/GinieSystem/NightSchool/` structure created
+- [ ] Dependencies installed (`anthropic`, `pyyaml`, `faiss-cpu`, `jsonschema`)
+- [ ] Config files reviewed and customized
+- [ ] At least 24 hours of `L1_RAW` logs available
+
+## Test Run (Manual)
+```bash
+cd ~/GinieSystem/NightSchool
+python night_school.py --dry-run
+python night_school.py
+```
+
+## Verify Outputs
+- [ ] Check `logs/night_school_YYYYMMDD.log`
+- [ ] Verify `L2_SEMANTIC/episodes.db` has entries
+- [ ] Verify `L3_SKILL_DECK/` has skill cards
+- [ ] Check `snapshots/snapshot_YYYYMMDD.json` size < 3k tokens
+- [ ] Review first Skill Cards for quality
+
+## Integration
+- [ ] Test loading snapshot in external LLM conversation
+- [ ] Verify Skill Cards are actionable
+- [ ] Connect to GUARDIAN for validation
+- [ ] Update module logging to ensure L1_RAW capture
+
+## Monitoring (Week 1)
+- [ ] Daily: Check Night School completion
+- [ ] Check storage growth (should plateau after pruning)
+- [ ] Validate Skill Card confidence scores
+- [ ] Test retrieval: Ask system to use a skill

--- a/NightSchool/config/module_configs/biocore_child.yaml
+++ b/NightSchool/config/module_configs/biocore_child.yaml
@@ -1,0 +1,3 @@
+module: biocore_child
+priority: high
+notes: "Child safety and biometric signal processing"

--- a/NightSchool/config/module_configs/g_motor.yaml
+++ b/NightSchool/config/module_configs/g_motor.yaml
@@ -1,0 +1,3 @@
+module: g_motor
+priority: low
+notes: "Economic optimization and ROI tuning focus module"

--- a/NightSchool/config/module_configs/guardian.yaml
+++ b/NightSchool/config/module_configs/guardian.yaml
@@ -1,0 +1,3 @@
+module: guardian
+priority: high
+notes: "Validation and oversight layer"

--- a/NightSchool/config/module_configs/nexus_prime.yaml
+++ b/NightSchool/config/module_configs/nexus_prime.yaml
@@ -1,0 +1,3 @@
+module: nexus_prime
+priority: medium
+notes: "Coordination and orchestration across modules"

--- a/NightSchool/config/night_school.yaml
+++ b/NightSchool/config/night_school.yaml
@@ -1,0 +1,52 @@
+schedule:
+  night_school_start: "02:00"
+  quick_sync: "14:00"
+
+timing:
+  episode_collection: "15 min"
+  clustering: "10 min"
+  skill_synthesis: "20 min"
+  pruning: "5 min"
+  snapshot_export: "3 min"
+  total_estimated: "~50 min"
+
+modules:
+  enabled:
+    - g_motor
+    - biocore_child
+    - nexus_prime
+    - guardian
+  priority:
+    high: [biocore_child, guardian]
+    medium: [nexus_prime]
+    low: [g_motor]
+
+storage:
+  L1_RAW:
+    ttl_days: 30
+    compression: "zstd"
+    max_size_gb: 2
+  L2_SEMANTIC:
+    max_episodes: 50000
+    prune_threshold: 0.3
+    cluster_recompute: "weekly"
+  L3_SKILL_DECK:
+    max_cards_per_module: 200
+    archive_unused_days: 60
+    min_confidence: 0.5
+
+anthropic:
+  models:
+    collector: "sonnet-4.5"
+    clusterer: "sonnet-4.5"
+    synthesizer: "opus-4.5"
+    pruner: "haiku-4.0"
+  rate_limits:
+    max_requests_per_minute: 50
+    retry_backoff: "exponential"
+
+output:
+  snapshot_format: "json"
+  snapshot_max_tokens: 3000
+  top_n_skills: 30
+  include_stats: true

--- a/NightSchool/config/schemas/skill_card_v2.json
+++ b/NightSchool/config/schemas/skill_card_v2.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Skill Card v2",
+  "type": "object",
+  "required": ["id", "module", "topic", "rule", "anti_rule", "confidence"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^SKILL:[A-Z_]+:[A-Z_]+:[0-9]{3}$"
+    },
+    "module": {
+      "type": "string",
+      "enum": ["g_motor", "biocore_child", "nexus_prime", "guardian", "common"]
+    },
+    "topic": {
+      "type": "string",
+      "maxLength": 50
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "rule": {
+      "type": "object",
+      "required": ["trigger", "action", "expected_outcome"],
+      "properties": {
+        "trigger": {"type": "string"},
+        "action": {"type": "string"},
+        "expected_outcome": {"type": "string"}
+      }
+    },
+    "anti_rule": {
+      "type": "object",
+      "required": ["never_when", "reason"],
+      "properties": {
+        "never_when": {"type": ["string", "array"]},
+        "reason": {"type": "string"}
+      }
+    },
+    "evidence": {"type": "object"},
+    "metadata": {"type": "object"}
+  }
+}

--- a/NightSchool/config/skill_card_schema.json
+++ b/NightSchool/config/skill_card_schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Skill Card v2",
+  "type": "object",
+  "required": ["id", "module", "topic", "rule", "anti_rule", "confidence"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^SKILL:[A-Z_]+:[A-Z_]+:[0-9]{3}$"
+    },
+    "module": {
+      "type": "string",
+      "enum": ["g_motor", "biocore_child", "nexus_prime", "guardian", "common"]
+    },
+    "topic": {
+      "type": "string",
+      "maxLength": 50
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "rule": {
+      "type": "object",
+      "required": ["trigger", "action", "expected_outcome"],
+      "properties": {
+        "trigger": {"type": "string"},
+        "action": {"type": "string"},
+        "expected_outcome": {"type": "string"}
+      }
+    },
+    "anti_rule": {
+      "type": "object",
+      "required": ["never_when", "reason"],
+      "properties": {
+        "never_when": {"type": ["string", "array"]},
+        "reason": {"type": "string"}
+      }
+    },
+    "evidence": {"type": "object"},
+    "metadata": {"type": "object"}
+  }
+}

--- a/NightSchool/core/data_pruner.py
+++ b/NightSchool/core/data_pruner.py
@@ -1,0 +1,65 @@
+"""
+Data pruner applies TTL and pruning rules for Night School storage layers.
+"""
+
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+class DataPruner:
+    """Prune data in L1, L2, and L3 layers."""
+
+    def __init__(self, config: Dict, root: Path, dry_run: bool = False):
+        self.config = config
+        self.root = root
+        self.dry_run = dry_run
+        self.l1_path = self.root / "storage" / "L1_RAW"
+        self.l2_path = self.root / "storage" / "L2_SEMANTIC"
+        self.l3_path = self.root / "storage" / "L3_SKILL_DECK"
+
+    def prune_all_layers(self) -> Dict:
+        total_bytes = 0
+        total_bytes += self._prune_l1()
+        total_bytes += self._prune_l2()
+        total_bytes += self._prune_l3()
+        return {"total_mb": total_bytes / (1024 * 1024)}
+
+    def _prune_l1(self) -> int:
+        ttl_days = self.config.get("storage", {}).get("L1_RAW", {}).get("ttl_days", 30)
+        cutoff = datetime.now() - timedelta(days=ttl_days)
+        return self._prune_folder(self.l1_path, cutoff)
+
+    def _prune_l2(self) -> int:
+        max_size_gb = self.config.get("storage", {}).get("L2_SEMANTIC", {}).get("max_episodes", 50000)
+        # Placeholder: no direct file size cap; rely on TTL by default
+        _ = max_size_gb
+        cutoff = datetime.now() - timedelta(days=90)
+        return self._prune_folder(self.l2_path, cutoff)
+
+    def _prune_l3(self) -> int:
+        archive_days = self.config.get("storage", {}).get("L3_SKILL_DECK", {}).get(
+            "archive_unused_days", 60
+        )
+        cutoff = datetime.now() - timedelta(days=archive_days)
+        return self._prune_folder(self.l3_path, cutoff, respect_suffix=".json")
+
+    def _prune_folder(self, path: Path, cutoff: datetime, respect_suffix: str | None = None) -> int:
+        if not path.exists():
+            return 0
+        freed_bytes = 0
+        for file_path in path.rglob("*" if respect_suffix is None else respect_suffix):
+            try:
+                modified = datetime.fromtimestamp(file_path.stat().st_mtime)
+                if modified < cutoff:
+                    freed_bytes += file_path.stat().st_size
+                    if not self.dry_run:
+                        file_path.unlink()
+            except FileNotFoundError:  # pragma: no cover - file might be removed in race
+                continue
+        if freed_bytes:
+            logger.info("Pruned %.2f MB from %s", freed_bytes / (1024 * 1024), path)
+        return freed_bytes

--- a/NightSchool/core/episode_collector.py
+++ b/NightSchool/core/episode_collector.py
@@ -1,0 +1,100 @@
+"""
+Episode Collector - Step 1 of Night School
+Collects raw experiences and converts to structured episodes.
+"""
+
+import json
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Dict
+
+from anthropic import Anthropic
+
+logger = logging.getLogger(__name__)
+
+
+class EpisodeCollector:
+    """Collects and structures raw operational data into episodes."""
+
+    def __init__(self, config: Dict, root: Path):
+        self.config = config
+        self.root = root
+        self.client = Anthropic()
+        self.l1_path = self.root / "storage" / "L1_RAW"
+        self.l2_path = self.root / "storage" / "L2_SEMANTIC"
+        self.l1_path.mkdir(parents=True, exist_ok=True)
+        self.l2_path.mkdir(parents=True, exist_ok=True)
+
+    def collect_from_module(self, module_name: str) -> List[Dict]:
+        raw_logs = self._load_recent_logs(module_name)
+        if not raw_logs:
+            logger.warning("No logs found for %s", module_name)
+            return []
+
+        episodes = self._extract_episodes(module_name, raw_logs)
+        return episodes
+
+    def _load_recent_logs(self, module_name: str) -> List[Dict]:
+        log_dir = self.l1_path / module_name
+        if not log_dir.exists():
+            return []
+
+        cutoff = datetime.now() - timedelta(days=1)
+        recent_logs = []
+        for log_file in log_dir.glob("*.log"):
+            if datetime.fromtimestamp(log_file.stat().st_mtime) > cutoff:
+                with open(log_file, "r", encoding="utf-8") as handle:
+                    recent_logs.append({"file": str(log_file), "content": handle.read()})
+        return recent_logs
+
+    def _extract_episodes(self, module_name: str, raw_logs: List[Dict]) -> List[Dict]:
+        combined = "\n\n".join([f"=== {log['file']} ===\n{log['content']}" for log in raw_logs])
+        max_log_chars = 50000
+        if len(combined) > max_log_chars:
+            combined = combined[:max_log_chars] + "\n\n[TRUNCATED]"
+
+        prompt = f"""Extract structured learning episodes from these logs.
+
+MODULE: {module_name}
+LOGS:
+{combined}
+
+For each significant event (error, success, decision), create an episode with:
+- situation: what triggered this
+- action: what was done
+- result: what happened
+- timestamp: when it occurred
+- raw_refs: references to log lines
+
+OUTPUT: JSON array of episodes. Aim for 5-20 episodes max (focus on most significant).
+"""
+
+        try:
+            response = self.client.messages.create(
+                model=self.config["anthropic"]["models"].get("collector", "claude-sonnet-4.5"),
+                max_tokens=4000,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            episodes_raw = response.content[0].text
+            if "```json" in episodes_raw:
+                episodes_raw = episodes_raw.split("```json")[1].split("```")[0]
+            elif "```" in episodes_raw:
+                episodes_raw = episodes_raw.split("```")[1].split("```")[0]
+
+            episodes = json.loads(episodes_raw)
+            now_iso = datetime.now().isoformat()
+            for ep in episodes:
+                ep.setdefault("module", module_name)
+                ep.setdefault("collected_at", now_iso)
+            return episodes
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to extract episodes: %s", exc)
+            return []
+
+    def store_in_l2(self, episodes: List[Dict]) -> None:
+        episodes_db = self.l2_path / "episodes.db"
+        with open(episodes_db, "a", encoding="utf-8") as handle:
+            for episode in episodes:
+                handle.write(json.dumps(episode) + "\n")
+        logger.info("Stored %s episodes in L2_SEMANTIC", len(episodes))

--- a/NightSchool/core/semantic_clusterer.py
+++ b/NightSchool/core/semantic_clusterer.py
@@ -1,0 +1,62 @@
+"""
+Semantic clusterer groups recent episodes into topic clusters.
+"""
+
+import logging
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class SemanticClusterer:
+    """Simple clustering placeholder that groups episodes by module and theme keywords."""
+
+    def __init__(self, config: Dict, root: Path):
+        self.config = config
+        self.root = root
+        self.threshold = self.config.get("storage", {}).get("L2_SEMANTIC", {}).get(
+            "prune_threshold", 0.3
+        )
+
+    def cluster(self, episodes: List[Dict]) -> List[Dict]:
+        clusters: List[Dict] = []
+        grouped: Dict[str, List[Dict]] = defaultdict(list)
+        for episode in episodes:
+            key = episode.get("module", "common")
+            grouped[key].append(episode)
+
+        for module, module_eps in grouped.items():
+            if not module_eps:
+                continue
+            confidence_scores = [ep.get("confidence", 0.5) for ep in module_eps]
+            avg_conf = float(np.mean(confidence_scores)) if confidence_scores else 0.0
+            theme = self._infer_theme(module_eps)
+            clusters.append(
+                {
+                    "module": module,
+                    "theme": theme,
+                    "episodes": module_eps,
+                    "confidence": avg_conf,
+                }
+            )
+        return clusters
+
+    def _infer_theme(self, episodes: List[Dict]) -> str:
+        for episode in episodes:
+            situation = episode.get("situation", "")
+            if "roi" in situation.lower():
+                return "roi_optimization"
+            if "safety" in situation.lower():
+                return "safety_guardrails"
+        return episodes[0].get("module", "general") + "_general"
+
+    def validate_clusters(self, clusters: List[Dict]) -> List[Dict]:
+        valid = [c for c in clusters if c.get("confidence", 0.0) >= self.threshold]
+        pruned = len(clusters) - len(valid)
+        if pruned:
+            logger.info("Pruned %s low-confidence clusters", pruned)
+        return valid

--- a/NightSchool/core/skill_synthesizer.py
+++ b/NightSchool/core/skill_synthesizer.py
@@ -1,0 +1,118 @@
+"""
+Skill synthesis converts semantic clusters into Skill Cards.
+"""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from jsonschema import Draft7Validator
+
+logger = logging.getLogger(__name__)
+
+
+class SkillSynthesizer:
+    """Create and update Skill Cards from clusters."""
+
+    def __init__(self, config: Dict, root: Path, dry_run: bool = False):
+        self.config = config
+        self.root = root
+        self.dry_run = dry_run
+        schema_path = self.root / "config" / "skill_card_schema.json"
+        with open(schema_path, "r", encoding="utf-8") as handle:
+            self.schema = json.load(handle)
+        self.validator = Draft7Validator(self.schema)
+        self.deck_path = self.root / "storage" / "L3_SKILL_DECK"
+        self.deck_path.mkdir(parents=True, exist_ok=True)
+
+    def find_similar_skill(self, cluster: Dict) -> Optional[Dict]:
+        module_path = self.deck_path / cluster.get("module", "common")
+        if not module_path.exists():
+            return None
+        for card_file in module_path.glob("*.json"):
+            with open(card_file, "r", encoding="utf-8") as handle:
+                card = json.load(handle)
+                if card.get("topic") == cluster.get("theme"):
+                    card["_path"] = card_file
+                    return card
+        return None
+
+    def create_skill(self, cluster: Dict) -> Dict:
+        card = self._build_card(cluster)
+        self._validate(card)
+        if not self.dry_run:
+            self._persist_card(card)
+        return card
+
+    def update_skill(self, existing: Dict, cluster: Dict) -> Dict:
+        updated = self._build_card(cluster, existing_id=existing.get("id"))
+        updated.setdefault("metadata", {})["deprecates"] = [existing.get("id")]
+        self._validate(updated)
+        if not self.dry_run:
+            target_path = existing.get("_path") or self._build_path(updated)
+            self._persist_card(updated, target_path)
+        return updated
+
+    def _build_card(self, cluster: Dict, existing_id: Optional[str] = None) -> Dict:
+        module = cluster.get("module", "common")
+        card_id = existing_id or self._generate_id(module, cluster.get("theme", "general"))
+        now_iso = datetime.utcnow().isoformat() + "Z"
+        episodes = cluster.get("episodes", [])
+        evidence_refs = [ep.get("raw_refs", []) for ep in episodes]
+        flattened_refs = [item for sublist in evidence_refs for item in (sublist or [])]
+
+        card = {
+            "$schema": "./schemas/skill_card_v2.json",
+            "id": card_id,
+            "version": "2.0",
+            "module": module,
+            "topic": cluster.get("theme", "general"),
+            "created": now_iso,
+            "last_updated": now_iso,
+            "confidence": float(cluster.get("confidence", 0.5)),
+            "rule": {
+                "trigger": "Derived from latest semantic cluster",
+                "action": "Summarize best-known mitigation and optimization steps",
+                "expected_outcome": "Operational improvement based on synthesized experience",
+            },
+            "anti_rule": {
+                "never_when": "Strategic experiments or trusted partner overrides",
+                "reason": "Special cases may require separate evaluation",
+            },
+            "evidence": {
+                "episode_count": len(episodes),
+                "success_rate": float(cluster.get("confidence", 0.5)),
+                "refs": flattened_refs[:10],
+            },
+            "metadata": {
+                "impact_score": cluster.get("impact", 0.5),
+                "usage_count": 0,
+                "last_validated": now_iso,
+                "tags": [cluster.get("theme", "general")],
+            },
+        }
+        return card
+
+    def _generate_id(self, module: str, theme: str) -> str:
+        slug = theme.upper().replace(" ", "_")
+        return f"SKILL:{module.upper()}:{slug}:001"
+
+    def _validate(self, card: Dict) -> None:
+        errors = sorted(self.validator.iter_errors(card), key=lambda e: e.path)
+        if errors:
+            raise ValueError("Skill card validation failed: " + "; ".join(err.message for err in errors))
+
+    def _build_path(self, card: Dict) -> Path:
+        module_dir = self.deck_path / card.get("module", "common")
+        module_dir.mkdir(parents=True, exist_ok=True)
+        filename = f"{card['id'].replace(':', '_')}.json"
+        return module_dir / filename
+
+    def _persist_card(self, card: Dict, path: Optional[Path] = None) -> None:
+        target_path = path or self._build_path(card)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(target_path, "w", encoding="utf-8") as handle:
+            json.dump(card, handle, indent=2)
+        logger.info("Stored Skill Card at %s", target_path)

--- a/NightSchool/core/snapshot_exporter.py
+++ b/NightSchool/core/snapshot_exporter.py
@@ -1,0 +1,65 @@
+"""
+Snapshot exporter generates AI_SPEC_SNAPSHOT_v2 style artifacts.
+"""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotExporter:
+    """Builds a compact snapshot from skill cards and statistics."""
+
+    def __init__(self, config: Dict, root: Path, dry_run: bool = False):
+        self.config = config
+        self.root = root
+        self.dry_run = dry_run
+        self.deck_path = self.root / "storage" / "L3_SKILL_DECK"
+
+    def create_snapshot(self, top_n: int = 30) -> Dict:
+        skills = self._load_skills(top_n)
+        snapshot = {
+            "version": "AI_SPEC_SNAPSHOT_v2",
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "skill_cards": skills,
+            "core_state": {
+                "modules": self.config.get("modules", {}),
+                "storage": self.config.get("storage", {}),
+                "anthropic": self.config.get("anthropic", {}).get("models", {}),
+            },
+            "stats": {
+                "skill_count": len(skills),
+                "top_n": top_n,
+                "size_tokens": self._estimate_tokens(skills),
+            },
+        }
+        return snapshot
+
+    def save_snapshot(self, snapshot: Dict, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(snapshot, handle, indent=2)
+        logger.info("Saved snapshot to %s", path)
+
+    def _load_skills(self, top_n: int) -> List[Dict]:
+        skills: List[Dict] = []
+        if not self.deck_path.exists():
+            return skills
+        for card_path in sorted(self.deck_path.rglob("*.json")):
+            try:
+                with open(card_path, "r", encoding="utf-8") as handle:
+                    card = json.load(handle)
+                    skills.append(card)
+            except json.JSONDecodeError:  # pragma: no cover - skip corrupted cards
+                continue
+        # Sort by confidence descending
+        skills.sort(key=lambda c: c.get("confidence", 0), reverse=True)
+        return skills[:top_n]
+
+    def _estimate_tokens(self, skills: List[Dict]) -> int:
+        approx_chars = sum(len(json.dumps(skill)) for skill in skills)
+        return int(approx_chars / 4)  # rough text token approximation

--- a/NightSchool/night_school.py
+++ b/NightSchool/night_school.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Night School - Main Orchestrator
+Implements NANOTECH_INTEL_MEMORY_v2 learning pipeline.
+"""
+
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+import argparse
+import yaml
+
+from core.episode_collector import EpisodeCollector
+from core.semantic_clusterer import SemanticClusterer
+from core.skill_synthesizer import SkillSynthesizer
+from core.data_pruner import DataPruner
+from core.snapshot_exporter import SnapshotExporter
+
+LOG_DIR = Path(__file__).resolve().parent / "logs"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler(LOG_DIR / f"night_school_{datetime.now().strftime('%Y%m%d')}.log"),
+        logging.StreamHandler(sys.stdout),
+    ],
+)
+logger = logging.getLogger(__name__)
+
+
+class NightSchool:
+    """Main Night School orchestrator."""
+
+    def __init__(self, config_path: str = "config/night_school.yaml", dry_run: bool = False):
+        self.root = Path(__file__).resolve().parent
+        self.config_path = self.root / config_path
+        self.dry_run = dry_run
+
+        logger.info("🌙 Initializing Night School...")
+        with open(self.config_path, "r", encoding="utf-8") as f:
+            self.config = yaml.safe_load(f)
+
+        self.episode_collector = EpisodeCollector(self.config, root=self.root)
+        self.clusterer = SemanticClusterer(self.config, root=self.root)
+        self.synthesizer = SkillSynthesizer(self.config, root=self.root, dry_run=dry_run)
+        self.pruner = DataPruner(self.config, root=self.root, dry_run=dry_run)
+        self.exporter = SnapshotExporter(self.config, root=self.root, dry_run=dry_run)
+
+        self.stats = {
+            "start_time": datetime.now(),
+            "episodes_collected": 0,
+            "clusters_found": 0,
+            "skills_created": 0,
+            "skills_updated": 0,
+            "data_pruned_mb": 0.0,
+        }
+
+    def run(self) -> bool:
+        logger.info("=" * 60)
+        logger.info("🎓 NIGHT SCHOOL SESSION STARTING")
+        logger.info(f"Time: {self.stats['start_time']}")
+        logger.info("=" * 60)
+
+        try:
+            episodes = self.step_1_collect_episodes()
+            logger.info("✅ Collected %s episodes", len(episodes))
+
+            clusters = self.step_2_cluster_episodes(episodes)
+            logger.info("✅ Identified %s knowledge clusters", len(clusters))
+
+            skills = self.step_3_synthesize_skills(clusters)
+            logger.info("✅ Created/updated %s Skill Cards", len(skills))
+
+            pruned_mb = self.step_4_prune_data()
+            logger.info("✅ Freed %.1f MB of storage", pruned_mb)
+
+            snapshot = self.step_5_export_snapshot()
+            logger.info("✅ Snapshot tokens: %s", snapshot.get("size_tokens", 0))
+
+            self.print_final_report()
+            return True
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("❌ Night School failed: %s", exc, exc_info=True)
+            return False
+
+    def step_1_collect_episodes(self):
+        all_episodes = []
+        for module in self.config["modules"].get("enabled", []):
+            logger.info("  Collecting from %s...", module)
+            try:
+                episodes = self.episode_collector.collect_from_module(module)
+                all_episodes.extend(episodes)
+                logger.info("    → %s episodes", len(episodes))
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error("    ⚠️ Failed to collect from %s: %s", module, exc)
+
+        if not self.dry_run:
+            self.episode_collector.store_in_l2(all_episodes)
+
+        self.stats["episodes_collected"] = len(all_episodes)
+        return all_episodes
+
+    def step_2_cluster_episodes(self, episodes):
+        clusters = self.clusterer.cluster(episodes)
+        validated_clusters = self.clusterer.validate_clusters(clusters)
+        self.stats["clusters_found"] = len(validated_clusters)
+        return validated_clusters
+
+    def step_3_synthesize_skills(self, clusters):
+        new_skills = []
+        updated_skills = []
+        for cluster in clusters:
+            logger.info("  Processing cluster: %s", cluster.get("theme", "unknown"))
+            try:
+                existing = self.synthesizer.find_similar_skill(cluster)
+                if existing:
+                    updated = self.synthesizer.update_skill(existing, cluster)
+                    updated_skills.append(updated)
+                    logger.info("    ↻ Updated: %s", updated.get("id"))
+                else:
+                    created = self.synthesizer.create_skill(cluster)
+                    new_skills.append(created)
+                    logger.info("    ✨ Created: %s", created.get("id"))
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error("    ⚠️ Failed to synthesize skill: %s", exc)
+
+        self.stats["skills_created"] = len(new_skills)
+        self.stats["skills_updated"] = len(updated_skills)
+        return new_skills + updated_skills
+
+    def step_4_prune_data(self):
+        pruned = self.pruner.prune_all_layers()
+        self.stats["data_pruned_mb"] = pruned.get("total_mb", 0.0)
+        return pruned.get("total_mb", 0.0)
+
+    def step_5_export_snapshot(self):
+        snapshot = self.exporter.create_snapshot(
+            top_n=self.config["output"].get("top_n_skills", 30)
+        )
+        if not self.dry_run:
+            snapshot_path = self.root / "snapshots" / f"snapshot_{datetime.now().strftime('%Y%m%d')}.json"
+            self.exporter.save_snapshot(snapshot, snapshot_path)
+        return snapshot
+
+    def print_final_report(self):
+        duration = (datetime.now() - self.stats["start_time"]).total_seconds() / 60
+        logger.info("\n" + "=" * 60)
+        logger.info("🎓 NIGHT SCHOOL SESSION COMPLETE")
+        logger.info("=" * 60)
+        logger.info("Duration: %.1f minutes", duration)
+        logger.info("Episodes collected: %s", self.stats["episodes_collected"])
+        logger.info("Clusters found: %s", self.stats["clusters_found"])
+        logger.info("Skills created: %s", self.stats["skills_created"])
+        logger.info("Skills updated: %s", self.stats["skills_updated"])
+        logger.info("Storage freed: %.1f MB", self.stats["data_pruned_mb"])
+        logger.info("=" * 60)
+        logger.info("💤 System ready for next day of learning.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Night School - Knowledge Synthesis System")
+    parser.add_argument("--config", default="config/night_school.yaml", help="Config file")
+    parser.add_argument("--dry-run", action="store_true", help="Simulate without changes")
+    args = parser.parse_args()
+
+    school = NightSchool(config_path=args.config, dry_run=args.dry_run)
+    success = school.run()
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/NightSchool/storage/L3_SKILL_DECK/g_motor/SKILL_G_MOTOR_ROI_TUNING_001.json
+++ b/NightSchool/storage/L3_SKILL_DECK/g_motor/SKILL_G_MOTOR_ROI_TUNING_001.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "./schemas/skill_card_v2.json",
+  "id": "SKILL:G_MOTOR:ROI_TUNING:001",
+  "version": "2.0",
+  "module": "g_motor",
+  "topic": "roi_optimization",
+  "created": "2025-12-01T02:15:00Z",
+  "last_updated": "2025-12-01T02:15:00Z",
+  "confidence": 0.87,
+  "rule": {
+    "trigger": "When job proposal has ROI < threshold AND risk_score > 0.6",
+    "action": "Adjust criteria: increase required ROI by 15%, flag for manual review if strategic importance > 0.8",
+    "expected_outcome": "Better hit rate on profitable jobs, reduced wasted compute"
+  },
+  "anti_rule": {
+    "never_when": "Job is marked as 'strategic_experiment' OR comes from trusted_partner list",
+    "reason": "Strategic jobs may have indirect ROI not captured in immediate metrics"
+  },
+  "evidence": {
+    "episode_count": 23,
+    "success_rate": 0.87,
+    "refs": [
+      "L2_SEMANTIC:cluster_42",
+      "L2_SEMANTIC:cluster_58",
+      "L1_RAW:economy/2025-11-28_roi_analysis.log"
+    ]
+  },
+  "metadata": {
+    "impact_score": 0.82,
+    "usage_count": 156,
+    "last_validated": "2025-12-01T02:15:00Z",
+    "tags": [
+      "economy",
+      "optimization",
+      "risk_management"
+    ],
+    "deprecates": ["SKILL:G_MOTOR:ROI_TUNING:000"]
+  }
+}

--- a/scripts/install_night_school.sh
+++ b/scripts/install_night_school.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# install_night_school.sh
+set -euo pipefail
+
+ROOT="${HOME}/GinieSystem/NightSchool"
+
+echo "🎓 Installing Night School to ${ROOT}..."
+
+mkdir -p "${ROOT}"/{config,core,storage/{L1_RAW,L2_SEMANTIC,L3_SKILL_DECK/{g_motor,biocore_child,nexus_prime,guardian}},snapshots,logs}
+
+pip install anthropic pyyaml faiss-cpu numpy voyageai jsonschema
+
+cp -r NightSchool/config "${ROOT}/"
+cp -r NightSchool/core "${ROOT}/"
+cp NightSchool/night_school.py "${ROOT}/"
+
+(crontab -l 2>/dev/null; echo "0 2 * * * cd ${ROOT} && python night_school.py >> logs/cron.log 2>&1") | crontab -
+(crontab -l 2>/dev/null; echo "0 14 * * * cd ${ROOT} && python night_school.py --dry-run >> logs/cron.log 2>&1") | crontab -
+
+echo "✅ Night School installed!"
+echo "📅 Scheduled to run at 02:00 daily"
+echo "🧪 Test with: cd ${ROOT} && python night_school.py"


### PR DESCRIPTION
## Summary
- add Night School orchestrator with episode collection, clustering, skill synthesis, pruning, and snapshot export
- include configuration, module presets, schema validation, and seeded Skill Card example for ROI tuning
- provide installation script and first-run checklist for deploying the nightly pipeline

## Testing
- python -m compileall NightSchool

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e211b2a8c832fb7cbbccfb9456d43)