### PR TITLE
Add helper and docs recommending Hermes 4.3-36B (Q4_K_M) and installer script

### DIFF
--- a/Docs/Hermes_Best_Version.md
+++ b/Docs/Hermes_Best_Version.md
@@ -1,0 +1,36 @@
+# Best Hermes Version
+
+Use **Hermes 4.3 36B** as the default "best Hermes" model for local/private inference.
+
+## Recommendation
+
+| Use case | Pick | Why |
+| --- | --- | --- |
+| Best balanced local Hermes model | `NousResearch/Hermes-4.3-36B-GGUF` with `hermes-4_3_36b-Q4_K_M.gguf` | Current flagship Hermes 4.3 model; Q4_K_M is the practical quality/size balance at ~21.8 GB. |
+| Higher quality if you have more VRAM/disk | `hermes-4_3_36b-Q5_K_M.gguf` or `Q6_K` | Better quantization quality, but larger downloads and memory use. |
+| Smallest practical 4.3 option | `hermes-4_3_36b-Q3_K_M.gguf` | Lower memory/disk use at the cost of output quality. |
+| Hermes Agent app/runtime | Latest official release `v2026.4.30` | Latest GitHub release at the time this repository note was updated. |
+
+## Source notes
+
+- Nous Research describes Hermes 4.3 as an update to its flagship Hermes series, based on Seed-OSS-36B-Base, with up to 512K context and near Hermes 4 70B performance at roughly half the parameter count.
+- The Hugging Face Hermes 4 collection lists `NousResearch/Hermes-4.3-36B` and `NousResearch/Hermes-4.3-36B-GGUF` ahead of the earlier Hermes 4 variants.
+- The official GGUF repository provides `Q3_K_M`, `Q4_K_M`, `Q5_K_M`, `Q6_K`, `Q8_0`, and full GGUF files; `Q4_K_M` is the recommended default for this repo because it is the smallest quantization that still preserves strong model behavior for everyday agent use.
+- The Hermes Agent GitHub latest release resolves to `v2026.4.30` / Hermes Agent `v0.12.0`.
+
+## Quick command
+
+From the repository root, use:
+
+```bash
+Scripts/get_best_hermes.sh info
+```
+
+To download the recommended official GGUF and create an Ollama model when the required tools are installed:
+
+```bash
+Scripts/get_best_hermes.sh download
+Scripts/get_best_hermes.sh ollama
+```
+
+The script defaults to storing the GGUF under `${HOME}/.cache/ginie/hermes` and names the local Ollama model `hermes-4.3-36b:q4_k_m`.

--- a/Scripts/get_best_hermes.sh
+++ b/Scripts/get_best_hermes.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Best Hermes defaults, verified 2026-05-05 from official Nous/Hugging Face/GitHub pages.
+HERMES_MODEL_REPO="${HERMES_MODEL_REPO:-NousResearch/Hermes-4.3-36B-GGUF}"
+HERMES_MODEL_FILE="${HERMES_MODEL_FILE:-hermes-4_3_36b-Q4_K_M.gguf}"
+HERMES_MODEL_ALIAS="${HERMES_MODEL_ALIAS:-hermes-4.3-36b:q4_k_m}"
+HERMES_AGENT_RELEASE="${HERMES_AGENT_RELEASE:-v2026.4.30}"
+HERMES_CACHE_DIR="${HERMES_CACHE_DIR:-$HOME/.cache/ginie/hermes}"
+HERMES_MODEL_PATH="$HERMES_CACHE_DIR/$HERMES_MODEL_FILE"
+HERMES_MODEL_URL="https://huggingface.co/$HERMES_MODEL_REPO/resolve/main/$HERMES_MODEL_FILE"
+
+say() { printf '%s\n' "$*"; }
+fail() { say "❌ $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"; }
+
+usage() {
+  cat <<USAGE
+Usage: ${0##*/} <info|download|ollama|agent-command>
+
+Commands:
+  info           Print the recommended Hermes versions and local paths.
+  download       Download the official Hermes 4.3 36B Q4_K_M GGUF.
+  ollama         Create/pull the local Ollama model alias from the downloaded GGUF.
+  agent-command  Print the official Hermes Agent install command pinned to $HERMES_AGENT_RELEASE.
+
+Environment overrides:
+  HERMES_CACHE_DIR=$HERMES_CACHE_DIR
+  HERMES_MODEL_REPO=$HERMES_MODEL_REPO
+  HERMES_MODEL_FILE=$HERMES_MODEL_FILE
+  HERMES_MODEL_ALIAS=$HERMES_MODEL_ALIAS
+  HERMES_AGENT_RELEASE=$HERMES_AGENT_RELEASE
+USAGE
+}
+
+print_info() {
+  cat <<INFO
+Best Hermes model:      $HERMES_MODEL_REPO
+Recommended GGUF:       $HERMES_MODEL_FILE
+Local model path:       $HERMES_MODEL_PATH
+Ollama model alias:     $HERMES_MODEL_ALIAS
+Hermes Agent release:   $HERMES_AGENT_RELEASE
+
+Why this pick:
+- Hermes 4.3 36B is the current best balanced Hermes model for local/private inference.
+- Q4_K_M is the default quality/size balance; use Q5_K_M or Q6_K if you have more memory.
+- See Docs/Hermes_Best_Version.md for source notes and alternatives.
+INFO
+}
+
+download_model() {
+  mkdir -p "$HERMES_CACHE_DIR"
+  if [ -s "$HERMES_MODEL_PATH" ]; then
+    say "✅ Already downloaded: $HERMES_MODEL_PATH"
+    return 0
+  fi
+
+  if command -v huggingface-cli >/dev/null 2>&1; then
+    say "⬇️  Downloading with huggingface-cli: $HERMES_MODEL_REPO/$HERMES_MODEL_FILE"
+    huggingface-cli download "$HERMES_MODEL_REPO" "$HERMES_MODEL_FILE" \
+      --local-dir "$HERMES_CACHE_DIR" \
+      --local-dir-use-symlinks False
+  else
+    need curl
+    say "⬇️  Downloading with curl: $HERMES_MODEL_URL"
+    curl -L --fail --continue-at - --output "$HERMES_MODEL_PATH" "$HERMES_MODEL_URL"
+  fi
+
+  [ -s "$HERMES_MODEL_PATH" ] || fail "Download did not create $HERMES_MODEL_PATH"
+  say "✅ Downloaded: $HERMES_MODEL_PATH"
+}
+
+create_ollama_model() {
+  need ollama
+  [ -s "$HERMES_MODEL_PATH" ] || fail "Model file not found. Run: ${0##*/} download"
+
+  local modelfile
+  modelfile="$(mktemp)"
+  cat > "$modelfile" <<MODELFILE
+FROM $HERMES_MODEL_PATH
+PARAMETER num_ctx 32768
+MODELFILE
+
+  say "🧠 Creating Ollama model: $HERMES_MODEL_ALIAS"
+  ollama create "$HERMES_MODEL_ALIAS" -f "$modelfile"
+  rm -f "$modelfile"
+  say "✅ Ready: ollama run $HERMES_MODEL_ALIAS"
+}
+
+print_agent_command() {
+  cat <<COMMAND
+# Official installer pinned to the recommended Hermes Agent release tag.
+# Review remote scripts before running in sensitive environments.
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/$HERMES_AGENT_RELEASE/scripts/install.sh | bash
+COMMAND
+}
+
+cmd="${1:-info}"
+case "$cmd" in
+  info) print_info ;;
+  download) download_model ;;
+  ollama) create_ollama_model ;;
+  agent-command) print_agent_command ;;
+  -h|--help|help) usage ;;
+  *) usage >&2; fail "Unknown command: $cmd" ;;
+esac


### PR DESCRIPTION
### Motivation
- Provide a clear recommendation for the best Hermes model for local/private inference and document trade-offs for other quantizations.
- Add an easy-to-use, repo-local helper to fetch the recommended GGUF, create an Ollama model alias, and surface the pinned Hermes Agent installer command.
- Make the model choice and installer pin explicit to reduce guesswork and improve reproducible setup for local agents.

### Description
- Added `Docs/Hermes_Best_Version.md` documenting the recommended model `NousResearch/Hermes-4.3-36B-GGUF` and recommended GGUF `hermes-4_3_36b-Q4_K_M.gguf` plus alternatives and source notes. 
- Added executable `Scripts/get_best_hermes.sh` which supports commands `info`, `download`, `ollama`, and `agent-command` and exposes environment overrides for `HERMES_CACHE_DIR`, `HERMES_MODEL_REPO`, `HERMES_MODEL_FILE`, `HERMES_MODEL_ALIAS`, and `HERMES_AGENT_RELEASE`.
- `Scripts/get_best_hermes.sh` downloads the GGUF via `huggingface-cli` or `curl`, verifies the file, creates an Ollama model alias with `ollama create` (by writing a temporary modelfile), and prints a pinned Hermes Agent install command using `v2026.4.30` by default.

### Testing
- Ran `Scripts/get_best_hermes.sh info` which printed the recommended model, local paths, and rationale (succeeded).
- Ran `Scripts/get_best_hermes.sh agent-command` which printed the pinned Hermes Agent installer command (succeeded).
- Performed a shell syntax check with `bash -n Scripts/get_best_hermes.sh` to validate script syntax (succeeded); `shellcheck` was not available in the environment so a lint run was not performed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa7d39c2c8832fa45eddf3369d620c)