### PR TITLE
Add Anvil import→project→prefill flow: heuristics, storage, API and UI

### DIFF
--- a/Docs/ANVIL_PROJECT_LINK.md
+++ b/Docs/ANVIL_PROJECT_LINK.md
@@ -1,0 +1,32 @@
+# Anvil prosjektkobling (ASK-007)
+
+Denne mappen dokumenterer hvordan `deterministic_audit_mvp/giniesystem` kobles til Anvil-prosjektet og hvordan du verifiserer import → prosjekt → prefill-flyt.
+
+## Mapping
+- **App-rot:** `deterministic_audit_mvp/giniesystem`
+- **Anvil data-root:** `03_Workspace/anvil_data`
+- **Prosjektlager:** `03_Workspace/anvil_data/projects/*.json`
+
+## API-endepunkter
+- `POST /api/import` → oppretter import + prosjekt + prefill
+- `GET /api/projects` → liste over prosjekter
+- `GET /api/projects/:id` → prosjektmetadata
+- `PATCH /api/projects/:id` → oppdater prosjekt
+- `GET /api/projects/:id/prefill` → kalkulator-prefill
+- `POST /api/projects/:id/accept-prefill` → lagrer akseptert prefill
+
+## UI-sider
+- `/import` → last opp og analyser dokument
+- `/projects` → liste over prosjekter
+- `/projects/:id` → detaljer + prefill-aksept
+
+## Lokal testflyt (manuell)
+1. Start appen og gå til `/import`.
+2. Last opp et dokument og klikk **Analyser fil**.
+3. Klikk **Åpne prosjekt** for å verifisere at prosjekt + prefill er opprettet.
+4. Klikk **Bruk forslag (lagre på prosjekt)** for å teste lagring av prefill.
+
+## Verifiser lagring
+Sjekk at `03_Workspace/anvil_data/projects/<project_id>.json` har:
+- `project.accepted_prefill` etter aksept.
+- `prefill` satt fra heuristikk.

--- a/deterministic_audit_mvp/giniesystem/app/api/import/route.ts
+++ b/deterministic_audit_mvp/giniesystem/app/api/import/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { engine } from "@/lib/engine";
+import { createProjectFromImport } from "@/lib/project/createProjectFromImport";
+import { writeProjectBundle } from "@/lib/storage/projectsStore";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function json400(error: string, extra?: Record<string, unknown>) {
+  return NextResponse.json({ ok: false, error, ...(extra || {}) }, { status: 400 });
+}
+
+function looksLikePdfStructureText(text: string): boolean {
+  const sample = (text || "").slice(0, 3000);
+  return /%PDF-|\/XRef|xref|obj|endobj|stream|endstream/i.test(sample);
+}
+
+export async function POST(req: Request) {
+  try {
+    const contentType = (req.headers.get("content-type") || "").toLowerCase();
+    if (!contentType.includes("multipart/form-data")) {
+      return json400("Invalid upload: expected multipart/form-data");
+    }
+
+    const form = await req.formData().catch(() => null);
+    if (!form) return json400("Invalid upload: unreadable form-data payload");
+
+    const fileEntry = form.get("file");
+    if (!(fileEntry instanceof File)) {
+      return json400("Invalid upload: missing form-data field 'file'");
+    }
+    if (fileEntry.size === 0) return json400("Invalid upload: file is empty");
+
+    const file = fileEntry;
+    const filename = file.name || "upload.bin";
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    const record = await engine.process(buffer, filename);
+
+    const raw = String((record as { raw_text?: unknown })?.raw_text || "");
+    const structural = looksLikePdfStructureText(raw);
+    const tooShort = raw.trim().length < 40;
+    const lowConf = Number((record as { confidence?: unknown })?.confidence || 0) < 0.15;
+
+    if (structural || (tooShort && lowConf)) {
+      return json400("PDF_PARSE_FAILED", {
+        hint: "Dokumentet ser ut som korrupt/skannet/beskyttet PDF. Prøv Print→Save as PDF eller OCR før import.",
+        meta: {
+          structural,
+          tooShort,
+          lowConf,
+          raw_len: raw.length,
+          confidence: (record as { confidence?: unknown })?.confidence ?? null,
+        },
+      });
+    }
+
+    const import_id = String((record as { id?: unknown })?.id || `${Date.now()}_${Math.random().toString(16).slice(2)}`);
+    const bundle = createProjectFromImport({ import_id, record });
+    writeProjectBundle(bundle);
+
+    return NextResponse.json({
+      ok: true,
+      id: import_id,
+      record,
+      project_id: bundle.project.id,
+    });
+  } catch (error: unknown) {
+    console.error("[ANVIL:API] Import error:", error);
+    return NextResponse.json(
+      { ok: false, error: "IMPORT_FAILED", detail: String((error as { message?: unknown })?.message || error) },
+      { status: 500 },
+    );
+  }
+}

--- a/deterministic_audit_mvp/giniesystem/app/api/projects/[id]/accept-prefill/route.ts
+++ b/deterministic_audit_mvp/giniesystem/app/api/projects/[id]/accept-prefill/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { acceptPrefill, readProjectBundle } from "@/lib/storage/projectsStore";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const body = await req.json().catch(() => ({}));
+  const bundle = readProjectBundle(id);
+  const accepted = {
+    assumptions: (body as { assumptions?: unknown }).assumptions ?? bundle.prefill.assumptions,
+    line_items: (body as { line_items?: unknown }).line_items ?? bundle.prefill.line_items,
+  };
+  const project = acceptPrefill(id, accepted);
+  return NextResponse.json({ ok: true, project, accepted_prefill: accepted });
+}

--- a/deterministic_audit_mvp/giniesystem/app/api/projects/[id]/prefill/route.ts
+++ b/deterministic_audit_mvp/giniesystem/app/api/projects/[id]/prefill/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { readProjectBundle } from "@/lib/storage/projectsStore";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const bundle = readProjectBundle(id);
+  return NextResponse.json(bundle.prefill);
+}

--- a/deterministic_audit_mvp/giniesystem/app/api/projects/[id]/route.ts
+++ b/deterministic_audit_mvp/giniesystem/app/api/projects/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { patchProject, readProjectBundle } from "@/lib/storage/projectsStore";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const bundle = readProjectBundle(id);
+  return NextResponse.json(bundle.project);
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const body = await req.json().catch(() => ({}));
+  const allowed = ["name", "customer_name", "contact_person", "phone", "email", "job_summary", "status"] as const;
+
+  const patch: Partial<Record<(typeof allowed)[number], unknown>> = {};
+  for (const key of allowed) {
+    if (key in body) patch[key] = body[key];
+  }
+
+  const project = patchProject(id, patch);
+  return NextResponse.json({ ok: true, project });
+}

--- a/deterministic_audit_mvp/giniesystem/app/api/projects/route.ts
+++ b/deterministic_audit_mvp/giniesystem/app/api/projects/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { listProjects } from "@/lib/storage/projectsStore";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const rows = listProjects();
+  return NextResponse.json(rows);
+}

--- a/deterministic_audit_mvp/giniesystem/app/import/page.tsx
+++ b/deterministic_audit_mvp/giniesystem/app/import/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, { useState } from "react";
+
+export default function ImportPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [resp, setResp] = useState<Record<string, unknown> | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function run() {
+    if (!file) return;
+    setBusy(true);
+    setResp(null);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/api/import", { method: "POST", body: fd });
+      const data = await res.json().catch(() => ({}));
+      setResp({ status: res.status, ...data });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 820, margin: "0 auto", padding: 18 }}>
+      <h1 style={{ fontSize: 22, fontWeight: 800 }}>Import</h1>
+
+      <div style={{ marginTop: 10, display: "flex", gap: 10, alignItems: "center" }}>
+        <input type="file" accept=".pdf,.txt" onChange={(event) => setFile(event.target.files?.[0] || null)} />
+        <button onClick={run} disabled={!file || busy} style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid #bbb" }}>
+          {busy ? "Jobber..." : "Analyser fil"}
+        </button>
+        <a
+          href="/projects"
+          style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid #ccc", textDecoration: "none" }}
+        >
+          Pågående prosjekter
+        </a>
+      </div>
+
+      {resp && (
+        <div style={{ marginTop: 14, padding: 12, borderRadius: 12, border: "1px solid #ddd" }}>
+          <div style={{ fontWeight: 700 }}>
+            {resp.ok ? "✅ Import OK" : "❌ Analyse feilet"} (HTTP {resp.status as number})
+          </div>
+
+          {resp.project_id && (
+            <div style={{ marginTop: 10 }}>
+              <a
+                href={`/projects/${resp.project_id}`}
+                style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid #bbb", textDecoration: "none", display: "inline-block" }}
+              >
+                Åpne prosjekt
+              </a>
+            </div>
+          )}
+
+          <pre style={{ whiteSpace: "pre-wrap", fontSize: 12, marginTop: 10 }}>{JSON.stringify(resp, null, 2)}</pre>
+
+          <div style={{ marginTop: 10 }}>
+            <button
+              onClick={() => navigator.clipboard.writeText(JSON.stringify(resp, null, 2))}
+              style={{ padding: "8px 12px", borderRadius: 8, border: "1px solid #bbb" }}
+            >
+              Kopier JSON
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/deterministic_audit_mvp/giniesystem/app/projects/[id]/page.tsx
+++ b/deterministic_audit_mvp/giniesystem/app/projects/[id]/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+
+type Project = {
+  id: string;
+  name: string;
+  customer_name: string;
+  contact_person?: string;
+  phone?: string;
+  email?: string;
+  job_summary: string;
+  status: string;
+  source_import_id: string;
+  accepted_prefill?: unknown;
+};
+
+type Prefill = {
+  project_id: string;
+  assumptions: Record<string, unknown>;
+  line_items: Array<{ name: string; hours: number }>;
+  confidence: number;
+};
+
+export default function ProjectPage({ params }: { params: { id: string } }) {
+  const id = params.id;
+  const [project, setProject] = useState<Project | null>(null);
+  const [prefill, setPrefill] = useState<Prefill | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function load() {
+    setErr(null);
+    setMsg(null);
+    const r1 = await fetch(`/api/projects/${id}`, { cache: "no-store" });
+    if (!r1.ok) return setErr(`Prosjekt ikke funnet (${r1.status})`);
+    const pj = await r1.json();
+    setProject(pj);
+
+    const r2 = await fetch(`/api/projects/${id}/prefill`, { cache: "no-store" });
+    if (r2.ok) setPrefill(await r2.json());
+  }
+
+  useEffect(() => {
+    load();
+  }, [id]);
+
+  const accepted = useMemo(() => project?.accepted_prefill || null, [project]);
+
+  async function acceptNow() {
+    if (!prefill) return;
+    setErr(null);
+    setMsg(null);
+    const res = await fetch(`/api/projects/${id}/accept-prefill`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ assumptions: prefill.assumptions, line_items: prefill.line_items }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data?.ok) return setErr(`Kunne ikke akseptere forslag (${data?.error || res.status})`);
+    setMsg("✅ Prefill akseptert og lagret på prosjektet");
+    await load();
+  }
+
+  return (
+    <div style={{ maxWidth: 980, margin: "0 auto", padding: 18 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
+        <div>
+          <div style={{ fontSize: 22, fontWeight: 800 }}>{project?.name || "Prosjekt"}</div>
+          <div style={{ fontSize: 13, opacity: 0.8 }}>
+            {project?.customer_name || ""} · status: {project?.status || ""} · import: {project?.source_import_id || ""}
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: 10 }}>
+          <a
+            href="/projects"
+            style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid #ccc", textDecoration: "none" }}
+          >
+            ← Til prosjekter
+          </a>
+          <a
+            href="/import"
+            style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid #ccc", textDecoration: "none" }}
+          >
+            Importer
+          </a>
+        </div>
+      </div>
+
+      {msg && (
+        <div style={{ marginTop: 12, padding: 12, borderRadius: 12, border: "1px solid #b7eb8f", background: "#f6ffed" }}>
+          {msg}
+        </div>
+      )}
+      {err && (
+        <div style={{ marginTop: 12, padding: 12, borderRadius: 12, border: "1px solid #f2b8b5", background: "#fff1f0" }}>
+          ❌ {err}
+        </div>
+      )}
+
+      <div style={{ marginTop: 14, display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <div style={{ padding: 14, borderRadius: 14, border: "1px solid #ddd" }}>
+          <div style={{ fontWeight: 800, marginBottom: 6 }}>Oppsummering</div>
+          <div style={{ whiteSpace: "pre-wrap", fontSize: 14 }}>{project?.job_summary || ""}</div>
+        </div>
+
+        <div style={{ padding: 14, borderRadius: 14, border: "1px solid #ddd" }}>
+          <div style={{ fontWeight: 800, marginBottom: 6 }}>Bestiller / kontakt</div>
+          <div style={{ fontSize: 14 }}>
+            <div><b>Kunde:</b> {project?.customer_name || ""}</div>
+            <div><b>E-post:</b> {project?.email || "-"}</div>
+            <div><b>Tlf:</b> {project?.phone || "-"}</div>
+          </div>
+        </div>
+
+        <div style={{ padding: 14, borderRadius: 14, border: "1px solid #ddd" }}>
+          <div style={{ fontWeight: 800, marginBottom: 6 }}>Kalkulator (prefill)</div>
+          {prefill ? (
+            <>
+              <div style={{ fontSize: 13, opacity: 0.85, marginBottom: 10 }}>
+                confidence: {(prefill.confidence ?? 0).toFixed(2)}
+              </div>
+              <div style={{ display: "grid", gap: 8 }}>
+                {(prefill.line_items || []).map((line, idx) => (
+                  <div
+                    key={`${line.name}-${idx}`}
+                    style={{ display: "flex", justifyContent: "space-between", border: "1px solid #eee", borderRadius: 10, padding: "8px 10px" }}
+                  >
+                    <span>{line.name}</span>
+                    <b>{line.hours} t</b>
+                  </div>
+                ))}
+              </div>
+              <button onClick={acceptNow} style={{ marginTop: 12, padding: "9px 12px", borderRadius: 10, border: "1px solid #bbb" }}>
+                Bruk forslag (lagre på prosjekt)
+              </button>
+            </>
+          ) : (
+            <div style={{ opacity: 0.8 }}>Ingen prefill funnet.</div>
+          )}
+        </div>
+
+        <div style={{ padding: 14, borderRadius: 14, border: "1px solid #ddd" }}>
+          <div style={{ fontWeight: 800, marginBottom: 6 }}>Akseptert prefill</div>
+          {accepted ? (
+            <pre style={{ whiteSpace: "pre-wrap", fontSize: 12, margin: 0 }}>{JSON.stringify(accepted, null, 2)}</pre>
+          ) : (
+            <div style={{ opacity: 0.8 }}>Ikke akseptert ennå.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/deterministic_audit_mvp/giniesystem/app/projects/page.tsx
+++ b/deterministic_audit_mvp/giniesystem/app/projects/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+type Project = {
+  id: string;
+  name: string;
+  customer_name: string;
+  status: string;
+  updated_at: string;
+};
+
+export default function ProjectsPage() {
+  const [rows, setRows] = useState<Project[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function load() {
+    setErr(null);
+    const res = await fetch("/api/projects", { cache: "no-store" });
+    if (!res.ok) return setErr(`Kunne ikke hente prosjekter (${res.status})`);
+    const data = await res.json();
+    setRows(Array.isArray(data) ? data : []);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: 18 }}>
+      <h1 style={{ fontSize: 22, fontWeight: 700 }}>Pågående prosjekter</h1>
+      <div style={{ marginTop: 10, display: "flex", gap: 10 }}>
+        <a
+          href="/import"
+          style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid #ccc", textDecoration: "none" }}
+        >
+          Importer dokument
+        </a>
+        <button onClick={load} style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid #ccc" }}>
+          Oppdater
+        </button>
+      </div>
+
+      {err && (
+        <div style={{ marginTop: 14, padding: 12, borderRadius: 12, border: "1px solid #f2b8b5", background: "#fff1f0" }}>
+          ❌ {err}
+        </div>
+      )}
+
+      <div style={{ marginTop: 14, display: "grid", gap: 10 }}>
+        {rows.map((project) => (
+          <a key={project.id} href={`/projects/${project.id}`} style={{ textDecoration: "none", color: "inherit" }}>
+            <div style={{ padding: 12, borderRadius: 14, border: "1px solid #ddd" }}>
+              <div style={{ fontWeight: 700 }}>{project.name}</div>
+              <div style={{ fontSize: 13, opacity: 0.8 }}>
+                {project.customer_name} · {project.status} · {new Date(project.updated_at).toLocaleString()}
+              </div>
+            </div>
+          </a>
+        ))}
+        {rows.length === 0 && (
+          <div style={{ padding: 12, borderRadius: 14, border: "1px dashed #ccc", opacity: 0.85 }}>
+            Ingen prosjekter ennå. Gå til Import og analyser et dokument.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/deterministic_audit_mvp/giniesystem/lib/heuristics/buildCalculatorPrefill.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/heuristics/buildCalculatorPrefill.ts
@@ -1,0 +1,26 @@
+export type PrefillLineItem = { name: string; hours: number };
+
+export function buildCalculatorPrefill(deliverables: string[] | undefined) {
+  const map = [
+    { re: /scada/i, name: "SCADA-integrasjon", hours: 120 },
+    { re: /dashboard/i, name: "Dashboard-utvikling", hours: 80 },
+    { re: /alarm/i, name: "Alarm-konfigurasjon", hours: 40 },
+    { re: /plc/i, name: "PLC-arbeid", hours: 60 },
+  ];
+
+  const items: PrefillLineItem[] = [];
+  for (const deliverable of deliverables || []) {
+    const hit = map.find((entry) => entry.re.test(deliverable));
+    if (hit) items.push({ name: hit.name, hours: hit.hours });
+  }
+  if (items.length === 0) items.push({ name: "Prosjektering", hours: 40 });
+
+  return {
+    assumptions: {
+      hourly_rate: 1200,
+      margin_target: 0.35,
+      risk_buffer_hours: 0.15,
+    },
+    line_items: items,
+  };
+}

--- a/deterministic_audit_mvp/giniesystem/lib/heuristics/buildJobSummary.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/heuristics/buildJobSummary.ts
@@ -1,0 +1,10 @@
+export function buildJobSummary(rawText: string): string {
+  const lines = (rawText || "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !/generated|placeholder|draft/i.test(line));
+
+  let summary = lines.slice(0, 10).join(" ");
+  if (summary.length < 120) summary = `${summary} Dokument analysert automatisk – manuell gjennomgang anbefalt.`.trim();
+  return summary.slice(0, 600);
+}

--- a/deterministic_audit_mvp/giniesystem/lib/heuristics/buildProjectName.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/heuristics/buildProjectName.ts
@@ -1,0 +1,4 @@
+export function buildProjectName(customer: string, deliverables: string[] | undefined, category: string, docType: string): string {
+  const top = (deliverables && deliverables[0]) ? deliverables[0] : (category || docType || "Prosjekt");
+  return `${customer} – ${top}`.slice(0, 140);
+}

--- a/deterministic_audit_mvp/giniesystem/lib/heuristics/classifyDocument.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/heuristics/classifyDocument.ts
@@ -1,0 +1,12 @@
+export type DocCategory = "AUTOMATION" | "GENERIC";
+export type DocType = "PROPOSAL" | "RFP" | "GENERIC";
+
+export function classifyDocument(rawText: string): { category: DocCategory; docType: DocType } {
+  const t = (rawText || "").toLowerCase();
+  const category: DocCategory = /scada|plc|alarm|dashboard|hmi/.test(t) ? "AUTOMATION" : "GENERIC";
+  const docType: DocType =
+    /proposal|tilbud|scope|deliverables/.test(t) ? "PROPOSAL" :
+    /requirement|shall|must|krav/.test(t) ? "RFP" :
+    "GENERIC";
+  return { category, docType };
+}

--- a/deterministic_audit_mvp/giniesystem/lib/heuristics/computeConfidence.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/heuristics/computeConfidence.ts
@@ -1,0 +1,9 @@
+export function computeConfidence(args: {
+  customerConfidence: number;
+  jobSummaryLength: number;
+  deliverablesCount: number;
+}): number {
+  const lenScore = args.jobSummaryLength > 300 ? 0.9 : args.jobSummaryLength > 150 ? 0.6 : 0.3;
+  const delScore = args.deliverablesCount > 2 ? 0.9 : args.deliverablesCount > 0 ? 0.6 : 0.3;
+  return Math.min(args.customerConfidence, lenScore, delScore);
+}

--- a/deterministic_audit_mvp/giniesystem/lib/heuristics/extractContact.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/heuristics/extractContact.ts
@@ -1,0 +1,6 @@
+export function extractContact(rawText: string): { email?: string; phone?: string } {
+  const text = rawText || "";
+  const email = text.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i)?.[0];
+  const phone = text.match(/(\+47\s?)?\d{8}/)?.[0];
+  return { email, phone };
+}

--- a/deterministic_audit_mvp/giniesystem/lib/heuristics/extractCustomer.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/heuristics/extractCustomer.ts
@@ -1,0 +1,15 @@
+export function extractCustomer(rawText: string): { name: string; confidence: number } {
+  const text = rawText || "";
+
+  const m = text.match(/([A-ZÆØÅ][A-Za-zÆØÅ0-9& ]+)\s+(AS|ASA|AB|OY|GMBH)\b/);
+  if (m) return { name: `${m[1].trim()} ${m[2].trim()}`, confidence: 0.9 };
+
+  if (/eramet/i.test(text)) return { name: "Eramet", confidence: 0.9 };
+  if (/northern punching/i.test(text)) return { name: "Northern Punching", confidence: 0.9 };
+  if (/weldone/i.test(text)) return { name: "WELDONE", confidence: 0.9 };
+
+  const m2 = text.match(/(kunde|client|customer)\s*:\s*(.+)/i);
+  if (m2 && m2[2]) return { name: m2[2].trim().slice(0, 120), confidence: 0.7 };
+
+  return { name: "Ukjent kunde", confidence: 0.2 };
+}

--- a/deterministic_audit_mvp/giniesystem/lib/heuristics/index.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/heuristics/index.ts
@@ -1,0 +1,7 @@
+export { classifyDocument } from "./classifyDocument";
+export { extractCustomer } from "./extractCustomer";
+export { extractContact } from "./extractContact";
+export { buildProjectName } from "./buildProjectName";
+export { buildJobSummary } from "./buildJobSummary";
+export { buildCalculatorPrefill } from "./buildCalculatorPrefill";
+export { computeConfidence } from "./computeConfidence";

--- a/deterministic_audit_mvp/giniesystem/lib/project/createProjectFromImport.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/project/createProjectFromImport.ts
@@ -1,0 +1,65 @@
+import {
+  buildCalculatorPrefill,
+  buildJobSummary,
+  buildProjectName,
+  classifyDocument,
+  computeConfidence,
+  extractContact,
+  extractCustomer,
+} from "@/lib/heuristics";
+import type { CalculatorPrefill, Project, ProjectIntake } from "@/lib/storage/projectsStore";
+
+export function createProjectFromImport(args: {
+  import_id: string;
+  record: Record<string, unknown>;
+}): { project: Project; intake: ProjectIntake; prefill: CalculatorPrefill } {
+  const raw = String(args.record?.raw_text || "");
+  const deliverables = Array.isArray(args.record?.deliverables) ? args.record.deliverables : [];
+  const requirements = Array.isArray(args.record?.requirements) ? args.record.requirements : [];
+
+  const { category, docType } = classifyDocument(raw);
+  const customer = extractCustomer(raw);
+  const contact = extractContact(raw);
+
+  const name = buildProjectName(customer.name, deliverables, category, docType);
+  const job_summary = buildJobSummary(raw);
+
+  const prefillTemplate = buildCalculatorPrefill(deliverables);
+  const conf = computeConfidence({
+    customerConfidence: customer.confidence,
+    jobSummaryLength: job_summary.length,
+    deliverablesCount: deliverables.length,
+  });
+
+  const now = new Date().toISOString();
+  const project: Project = {
+    id: `${Date.now()}_${Math.random().toString(16).slice(2, 14)}`,
+    name,
+    customer_name: customer.name,
+    phone: contact.phone,
+    email: contact.email,
+    job_summary,
+    source_import_id: args.import_id,
+    status: "ONGOING",
+    created_at: now,
+    updated_at: now,
+  };
+
+  const intake: ProjectIntake = {
+    project_id: project.id,
+    extracted_fields: { category, docType, customer_confidence: customer.confidence, contact },
+    confidence_map: { overall: conf },
+    doc_text_preview: raw.slice(0, 900),
+    deliverables,
+    requirements,
+  };
+
+  const prefill: CalculatorPrefill = {
+    project_id: project.id,
+    assumptions: prefillTemplate.assumptions,
+    line_items: prefillTemplate.line_items,
+    confidence: conf,
+  };
+
+  return { project, intake, prefill };
+}

--- a/deterministic_audit_mvp/giniesystem/lib/storage/projectsStore.ts
+++ b/deterministic_audit_mvp/giniesystem/lib/storage/projectsStore.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type ProjectStatus = "NEW" | "ONGOING" | "WON" | "LOST";
+
+export type Project = {
+  id: string;
+  name: string;
+  customer_name: string;
+  contact_person?: string;
+  phone?: string;
+  email?: string;
+  job_summary: string;
+  source_import_id: string;
+  status: ProjectStatus;
+  created_at: string;
+  updated_at: string;
+  accepted_prefill?: unknown;
+};
+
+export type ProjectIntake = {
+  project_id: string;
+  extracted_fields: Record<string, unknown>;
+  confidence_map: Record<string, unknown>;
+  doc_text_preview: string;
+  deliverables: string[];
+  requirements: string[];
+};
+
+export type CalculatorPrefill = {
+  project_id: string;
+  assumptions: Record<string, unknown>;
+  line_items: Array<{ name: string; hours: number }>;
+  confidence: number;
+};
+
+function rootDir(): string {
+  const root = process.env.ANVIL_DATA_ROOT || path.join(process.cwd(), "03_Workspace", "anvil_data");
+  fs.mkdirSync(path.join(root, "projects"), { recursive: true });
+  return root;
+}
+
+function projPath(id: string) {
+  return path.join(rootDir(), "projects", `${id}.json`);
+}
+
+export function listProjects(): Project[] {
+  const dir = path.join(rootDir(), "projects");
+  const files = fs.readdirSync(dir).filter((file) => file.endsWith(".json"));
+  const rows: Project[] = [];
+  for (const file of files) {
+    const raw = fs.readFileSync(path.join(dir, file), "utf8");
+    const obj = JSON.parse(raw);
+    if (obj?.project) rows.push(obj.project);
+  }
+  rows.sort((a, b) => (b.updated_at || "").localeCompare(a.updated_at || ""));
+  return rows;
+}
+
+export function readProjectBundle(
+  id: string,
+): { project: Project; intake: ProjectIntake; prefill: CalculatorPrefill } {
+  const raw = fs.readFileSync(projPath(id), "utf8");
+  return JSON.parse(raw);
+}
+
+export function writeProjectBundle(bundle: {
+  project: Project;
+  intake: ProjectIntake;
+  prefill: CalculatorPrefill;
+}) {
+  fs.writeFileSync(projPath(bundle.project.id), JSON.stringify(bundle, null, 2), "utf8");
+}
+
+export function patchProject(id: string, patch: Partial<Project>) {
+  const bundle = readProjectBundle(id);
+  bundle.project = { ...bundle.project, ...patch, updated_at: new Date().toISOString() };
+  writeProjectBundle(bundle);
+  return bundle.project;
+}
+
+export function acceptPrefill(id: string, accepted: unknown) {
+  const bundle = readProjectBundle(id);
+  bundle.project.accepted_prefill = accepted;
+  bundle.project.updated_at = new Date().toISOString();
+  writeProjectBundle(bundle);
+  return bundle.project;
+}


### PR DESCRIPTION
### Motivation
- Provide an end-to-end scaffold to turn uploaded documents into project bundles and calculator prefill data for the Anvil app. 
- Persist project bundles under the Anvil data-root so UI and APIs can list, view and accept prefills.
- Offer a small heuristics library to extract customer/contact info, classify documents and build prefill suggestions.

### Description
- Added a heuristics library in `deterministic_audit_mvp/giniesystem/lib/heuristics` with functions: `classifyDocument`, `extractCustomer`, `extractContact`, `buildProjectName`, `buildJobSummary`, `buildCalculatorPrefill` and `computeConfidence` and an `index.ts` export.
- Implemented project bundle creation in `lib/project/createProjectFromImport.ts` which composes heuristics output into a `project`, `intake` and `prefill` objects.
- Implemented a simple file-backed project store in `lib/storage/projectsStore.ts` that writes/reads `03_Workspace/anvil_data/projects/<id>.json` and supports listing, patching and accepting prefill.
- Added server API endpoints under `app/api`: `POST /api/import`, `GET /api/projects`, `GET|PATCH /api/projects/:id`, `GET /api/projects/:id/prefill`, and `POST /api/projects/:id/accept-prefill` to wire import→project→prefill flow.
- Added minimal client pages for manual verification: `app/import/page.tsx`, `app/projects/page.tsx`, and `app/projects/[id]/page.tsx` that exercise the new APIs and provide an "open project" and "accept prefill" UX.
- Added `Docs/ANVIL_PROJECT_LINK.md` documenting mappings, endpoints and a local manual test flow.

### Testing
- No automated test suite was executed for these changes because there is no runnable Next app in this path; `npm run lint`/`npm run build` were not run against the new app during this rollout.
- A git commit was created containing the 19 new files (commit succeeded). 
- Manual verification instructions were added in `Docs/ANVIL_PROJECT_LINK.md` for running the import→open project→accept prefill flow in a local/dev server.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6975fa96303c832fb7949cbd6af38786)